### PR TITLE
Add taskCountErrorLabel

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1402,6 +1402,11 @@ public interface OdeMessages extends Messages {
   @Description("Label to indicate the application has too many screens.")
   String formCountErrorLabel();
 
+  @DefaultMessage("WARNING: The number of tasks in this app might exceed the limits of App Inventor. " +
+                  "<p>Do you really want to add another task?</p>")
+  @Description("Label to indicate the application has too many tasks.")
+  String taskCountErrorLabel();
+
   @DefaultMessage("Screen names can contain only letters, numbers, and underscores and must " +
       "start with a letter")
   @Description("Error message when form name contains non-alphanumeric characters besides _")

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/AddTaskCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/AddTaskCommand.java
@@ -133,7 +133,7 @@ public final class AddTaskCommand extends ChainableCommand {
       taskCount = taskCount + 1;
       if (taskCount > MAX_TASK_COUNT) {
         HorizontalPanel errorPanel = new HorizontalPanel();
-        HTML tooManyTasksLabel = new HTML(MESSAGES.formCountErrorLabel());
+        HTML tooManyTasksLabel = new HTML(MESSAGES.taskCountErrorLabel());
         errorPanel.add(tooManyTasksLabel);
         errorPanel.setSize("100%", "24px");
         contentPanel.add(errorPanel);


### PR DESCRIPTION
When adding more than one task, the formCountErrorLabel is shown. I've added a taskCountErrorLabel so that the wording refers to tasks rather than screens.